### PR TITLE
WP7 hardening: thisismyurl-webp-support (v1.6148.2110)

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -34,7 +34,19 @@ jQuery( function ( $ ) {
         var pct = total > 0 ? Math.round( ( shown / total ) * 100 ) : 100;
         $( '#fwo-progress-bar' ).css( 'width', pct + '%' );
         $( '#fwo-progress-text' ).text( pct + '% (' + Math.round( shown ) + '/' + total + ')' );
+        /* Keep the progressbar role's state in sync with the visual width. */
+        $( '#fwo-progress-container' ).attr( 'aria-valuenow', pct );
         $( '#p-cnt' ).text( Math.max( 0, total - Math.round( shown ) ) );
+    }
+
+    /**
+     * Write a message into the polite live region so screen readers
+     * announce batch progress and results without stealing focus.
+     *
+     * @param {string} message Text to announce.
+     */
+    function announceStatus( message ) {
+        $( '#fwo-status-region' ).text( message );
     }
 
     function ensureBusyIndicator() {
@@ -231,6 +243,7 @@ jQuery( function ( $ ) {
         $( '#btn-cancel' ).show();
         $( '#fwo-progress-container' ).fadeIn();
         startBusyIndicator();
+        announceStatus( 'Optimizing ' + total + ' images. 0 percent complete.' );
 
         var processNextBatch = function () {
             if ( isCancelled || ! pendingIds.length ) {
@@ -291,14 +304,22 @@ jQuery( function ( $ ) {
                     updateProgress( total );
                     if ( pendingTable ) { pendingTable.refresh(); }
 
+                    var donePct = total > 0 ? Math.round( ( completed / total ) * 100 ) : 100;
+                    announceStatus(
+                        completed + ' of ' + total + ' images optimized, ' + donePct + ' percent complete.' +
+                        ( failed.length ? ' ' + failed.length + ' failed in this run.' : '' )
+                    );
+
                     if ( ! pendingIds.length ) {
                         stopBusyIndicator();
+                        announceStatus( 'Optimization complete. ' + completed + ' of ' + total + ' images processed.' );
                         window.location.reload();
                         return;
                     }
                 } )
                 .fail( function () {
                     isCancelled = true;
+                    announceStatus( 'Batch request failed or timed out. The queue was preserved; refresh to retry.' );
                     window.alert( 'Batch request failed or timed out. Queue was preserved, so refresh and retry will continue from the same items.' );
                 } )
                 .always( function () {
@@ -325,9 +346,24 @@ jQuery( function ( $ ) {
     ( function () {
         var custom = document.getElementById( 'timu-custom-quality' );
         if ( ! custom ) { return; }
+        var input = document.getElementById( 'timu-quality' );
+
+        function toggleCustom( show ) {
+            custom.style.display = show ? '' : 'none';
+            /* Keep the hidden field out of the accessibility tree and tab order
+               when it is not in context, and restore it when shown. */
+            if ( show ) {
+                custom.removeAttribute( 'aria-hidden' );
+                if ( input ) { input.disabled = false; }
+            } else {
+                custom.setAttribute( 'aria-hidden', 'true' );
+                if ( input ) { input.disabled = true; }
+            }
+        }
+
         document.querySelectorAll( '.timu-preset-radio' ).forEach( function ( radio ) {
             radio.addEventListener( 'change', function () {
-                custom.style.display = 'custom' === this.value ? '' : 'none';
+                toggleCustom( 'custom' === this.value );
             } );
         } );
     }() );

--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * WP 7 Abilities API registration for WEBP Support by thisismyurl.com.
+ *
+ * Exposes the plugin's non-destructive batch conversion and one-click
+ * restore operations as discoverable, REST/AI-invokable abilities. Both
+ * wrap the same static methods the WP-CLI commands call
+ * (TIMU_WEBP_Support::convert_to_webp() / ::restore_image()), so there is
+ * one code path per operation regardless of the invoking surface.
+ *
+ * @package TIMU_WEBP_Support
+ * @since   0.6149
+ */
+
+declare( strict_types = 1 );
+
+defined( 'ABSPATH' ) || exit;
+
+add_action(
+	'wp_abilities_api_init',
+	static function (): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return; // Abilities API unavailable (WordPress < 6.9).
+		}
+
+		wp_register_ability(
+			'thisismyurl-webp-support/convert',
+			array(
+				'label'               => __( 'Convert Media Library images to WebP/AVIF', 'thisismyurl-webp-support' ),
+				'description'         => __( 'Batch-converts pending Media Library images to the format configured in the plugin settings (WebP, AVIF, or both). Originals are backed up before conversion, so the operation is reversible via the restore ability. Use this to shrink image payloads across the library.', 'thisismyurl-webp-support' ),
+				'category'            => 'site',
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'limit' => array(
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'description' => __( 'Optional: maximum number of pending attachments to convert in this batch. If omitted, every pending attachment is converted.', 'thisismyurl-webp-support' ),
+						),
+					),
+					'additionalProperties' => false,
+					'default'              => array(),
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'required'             => array( 'converted', 'skipped', 'errors', 'space_saved_bytes' ),
+					'properties'           => array(
+						'converted'         => array(
+							'type'        => 'integer',
+							'description' => __( 'Number of attachments successfully converted in this batch.', 'thisismyurl-webp-support' ),
+						),
+						'skipped'           => array(
+							'type'        => 'integer',
+							'description' => __( 'Number of pending attachments left unprocessed because the limit was reached.', 'thisismyurl-webp-support' ),
+						),
+						'errors'            => array(
+							'type'        => 'integer',
+							'description' => __( 'Number of attachments that failed to convert.', 'thisismyurl-webp-support' ),
+						),
+						'space_saved_bytes' => array(
+							'type'        => 'integer',
+							'description' => __( 'Total bytes saved across the attachments converted in this batch.', 'thisismyurl-webp-support' ),
+						),
+						'error_messages'    => array(
+							'type'        => 'array',
+							'items'       => array(
+								'type' => 'string',
+							),
+							'description' => __( 'Human-readable failure messages, one per failed attachment.', 'thisismyurl-webp-support' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'execute_callback'    => static function ( $input = array() ) {
+					if ( ! class_exists( 'TIMU_WEBP_Support' ) ) {
+						return new WP_Error( 'timu_webp_unavailable', __( 'WEBP Support plugin is not loaded.', 'thisismyurl-webp-support' ) );
+					}
+
+					$input = is_array( $input ) ? $input : array();
+					$limit = isset( $input['limit'] ) ? absint( $input['limit'] ) : 0;
+
+					$lists = TIMU_WEBP_Support::get_media_lists();
+					$ids   = array_map(
+						static function ( $post ) {
+							return (int) $post->ID;
+						},
+						$lists['pending']
+					);
+
+					$skipped = 0;
+					if ( $limit > 0 && count( $ids ) > $limit ) {
+						$skipped = count( $ids ) - $limit;
+						$ids     = array_slice( $ids, 0, $limit );
+					}
+
+					$converted          = 0;
+					$errors             = 0;
+					$space_saved_bytes  = 0;
+					$error_messages     = array();
+
+					foreach ( $ids as $id ) {
+						$result = TIMU_WEBP_Support::convert_to_webp( $id );
+
+						if ( true === $result ) {
+							++$converted;
+							$space_saved_bytes += (int) get_post_meta( $id, TIMU_WEBP_Support::SAVINGS_META_KEY, true );
+							continue;
+						}
+
+						++$errors;
+						$error_messages[] = is_wp_error( $result )
+							? sprintf( '#%d: %s', $id, $result->get_error_message() )
+							: sprintf( '#%d: %s', $id, __( 'unknown error', 'thisismyurl-webp-support' ) );
+					}
+
+					return array(
+						'converted'         => $converted,
+						'skipped'           => $skipped,
+						'errors'            => $errors,
+						'space_saved_bytes' => $space_saved_bytes,
+						'error_messages'    => $error_messages,
+					);
+				},
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => false, // Writes new image files and post meta.
+						'destructive' => false, // Originals are backed up before conversion; restore reverses it. Non-destructive by design.
+						'idempotent'  => false, // Each call converts whatever is pending; repeating with new pending items does more work.
+					),
+					'show_in_rest' => true, // Cap-guarded and non-destructive (originals are preserved).
+				),
+			)
+		);
+
+		wp_register_ability(
+			'thisismyurl-webp-support/restore',
+			array(
+				'label'               => __( 'Restore original images from backups', 'thisismyurl-webp-support' ),
+				'description'         => __( 'Restores every managed Media Library attachment that has a backup on disk, replacing the converted WebP/AVIF file with the original. Use this to roll back a conversion across the library.', 'thisismyurl-webp-support' ),
+				'category'            => 'site',
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'required'             => array( 'restored', 'errors' ),
+					'properties'           => array(
+						'restored' => array(
+							'type'        => 'integer',
+							'description' => __( 'Number of attachments successfully restored from backup.', 'thisismyurl-webp-support' ),
+						),
+						'errors'   => array(
+							'type'        => 'integer',
+							'description' => __( 'Number of attachments that could not be restored (for example, no backup on disk).', 'thisismyurl-webp-support' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'execute_callback'    => static function () {
+					if ( ! class_exists( 'TIMU_WEBP_Support' ) ) {
+						return new WP_Error( 'timu_webp_unavailable', __( 'WEBP Support plugin is not loaded.', 'thisismyurl-webp-support' ) );
+					}
+
+					$lists    = TIMU_WEBP_Support::get_media_lists();
+					$restored = 0;
+					$errors   = 0;
+
+					foreach ( $lists['media'] as $post ) {
+						$orig = get_post_meta( $post->ID, TIMU_WEBP_Support::BACKUP_META_KEY, true );
+						if ( ! $orig || 'external' === $orig ) {
+							continue; // No restorable backup for this attachment.
+						}
+
+						if ( TIMU_WEBP_Support::restore_image( (int) $post->ID ) ) {
+							++$restored;
+						} else {
+							++$errors;
+						}
+					}
+
+					return array(
+						'restored' => $restored,
+						'errors'   => $errors,
+					);
+				},
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => false, // Overwrites converted files with the originals and clears backup meta.
+						'destructive' => true,  // Overwrites the current converted state of each attachment.
+						'idempotent'  => true,  // After a restore the backup meta is cleared, so a second run finds nothing to restore: same end state.
+					),
+					'show_in_rest' => true, // Rule 7: fully guarded by a logged-in manage_options check, so REST exposure is acceptable.
+				),
+			)
+		);
+	}
+);

--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,9 @@ Yes. `wp webp convert <id|--all>`, `wp webp restore <id|--all>`, `wp webp status
 
 == Changelog ==
 
+= 1.6151 =
+* Uninstall: the companion-path meta (`_webp_companion_path`) written for "Both" (AVIF + WebP) attachments is now removed on uninstall, alongside the original-path and savings meta, so no orphan post meta survives.
+
 = 1.6150 =
 * Accessibility (WCAG 2.2 AA): the optimization progress bar now exposes `role="progressbar"` with `aria-valuenow/min/max` and an accessible label, and the admin script keeps `aria-valuenow` in sync with the visual width.
 * Accessibility: added a polite `role="status"` live region so screen readers announce batch progress, results, and completion.

--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,9 @@ Yes. `wp webp convert <id|--all>`, `wp webp restore <id|--all>`, `wp webp status
 
 == Changelog ==
 
+= 1.6149 =
+* Added WordPress 7.0 Abilities API support: `thisismyurl-webp-support/convert` (batch conversion) and `thisismyurl-webp-support/restore` (restore originals from backups), both guarded by the `manage_options` capability.
+
 = 1.6147 =
 * Unified plugin versioning to the x.Yddd calendar-version scheme.
 * Confirmed compatibility with WordPress 7.0.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: webp, images, media, optimization, compression
 Requires at least: 6.0
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 1.6147
+Stable tag: 1.6148.2110
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,13 @@ Yes. `wp webp convert <id|--all>`, `wp webp restore <id|--all>`, `wp webp status
 
 == Changelog ==
 
+= 1.6150 =
+* Accessibility (WCAG 2.2 AA): the optimization progress bar now exposes `role="progressbar"` with `aria-valuenow/min/max` and an accessible label, and the admin script keeps `aria-valuenow` in sync with the visual width.
+* Accessibility: added a polite `role="status"` live region so screen readers announce batch progress, results, and completion.
+* Accessibility: the "File Missing" status now carries a non-colour cue (warning icon and bold text) instead of signalling state by red colour alone.
+* Accessibility: the Output Format and Quality Preset radio groups are wrapped in `<fieldset>` with a screen-reader `<legend>` for a programmatic group name.
+* Accessibility: the custom-quality field is hidden from assistive technology and disabled when the Custom preset is not selected, and restored when it is.
+
 = 1.6149 =
 * Added WordPress 7.0 Abilities API support: `thisismyurl-webp-support/convert` (batch conversion) and `thisismyurl-webp-support/restore` (restore originals from backups), both guarded by the `manage_options` capability.
 

--- a/thisismyurl-webp-support.php
+++ b/thisismyurl-webp-support.php
@@ -1049,10 +1049,17 @@ class TIMU_WEBP_Support {
                                         </button>
                                     </div>
 
-                                    <div id="fwo-progress-container" style="display:none;margin-top:20px;background:#f0f0f1;height:30px;position:relative;border-radius:4px;overflow:hidden;border:1px solid #c3c4c7;">
+                                    <div id="fwo-progress-container"
+                                        role="progressbar"
+                                        aria-valuenow="0"
+                                        aria-valuemin="0"
+                                        aria-valuemax="100"
+                                        aria-label="<?php esc_attr_e( 'Batch optimization progress', 'thisismyurl-webp-support' ); ?>"
+                                        style="display:none;margin-top:20px;background:#f0f0f1;height:30px;position:relative;border-radius:4px;overflow:hidden;border:1px solid #c3c4c7;">
                                         <div id="fwo-progress-bar" style="background:#2271b1;height:100%;width:0%;transition:width 0.2s;"></div>
                                         <div id="fwo-progress-text" style="position:absolute;width:100%;text-align:center;top:0;line-height:30px;font-weight:bold;color:#fff;mix-blend-mode:difference;">0%</div>
                                     </div>
+                                    <div id="fwo-status-region" role="status" aria-live="polite" class="screen-reader-text"></div>
                                     <?php if ( $pending_bytes > 0 || $managed_savings > 0 ) : ?>
                                     <p class="description" style="margin-top:14px;">
                                         <?php
@@ -1092,6 +1099,8 @@ class TIMU_WEBP_Support {
                                         <tr>
                                             <th scope="row"><?php esc_html_e( 'Output Format', 'thisismyurl-webp-support' ); ?></th>
                                             <td>
+                                                <fieldset>
+                                                <legend class="screen-reader-text"><?php esc_html_e( 'Output Format', 'thisismyurl-webp-support' ); ?></legend>
                                                 <?php
                                                 $output_presets = array(
                                                     'webp' => __( 'WebP (recommended)', 'thisismyurl-webp-support' ),
@@ -1114,11 +1123,14 @@ class TIMU_WEBP_Support {
                                                         <?php endif; ?>
                                                     </label>
                                                 <?php endforeach; ?>
+                                                </fieldset>
                                             </td>
                                         </tr>
                                         <tr>
                                             <th scope="row"><?php esc_html_e( 'Quality Preset', 'thisismyurl-webp-support' ); ?></th>
                                             <td>
+                                                <fieldset>
+                                                <legend class="screen-reader-text"><?php esc_html_e( 'Quality Preset', 'thisismyurl-webp-support' ); ?></legend>
                                                 <?php
                                                 $quality_presets = array(
                                                     'web'      => __( 'Web (82) â€” balanced size/quality', 'thisismyurl-webp-support' ),
@@ -1138,13 +1150,16 @@ class TIMU_WEBP_Support {
                                                         <?php echo esc_html( $label ); ?>
                                                     </label>
                                                 <?php endforeach; ?>
-                                                <div id="timu-custom-quality" style="margin-top:8px;<?php echo 'custom' !== $cur_preset ? 'display:none;' : ''; ?>">
+                                                <?php $custom_hidden = ( 'custom' !== $cur_preset ); ?>
+                                                <div id="timu-custom-quality" style="margin-top:8px;<?php echo $custom_hidden ? 'display:none;' : ''; ?>"<?php echo $custom_hidden ? ' aria-hidden="true"' : ''; ?>>
                                                     <label for="timu-quality"><?php esc_html_e( 'Custom quality (0â€“100):', 'thisismyurl-webp-support' ); ?></label>
                                                     <input id="timu-quality" type="number" min="0" max="100"
                                                         name="<?php echo esc_attr( self::OPTION_KEY ); ?>[quality]"
                                                         value="<?php echo esc_attr( $options['quality'] ); ?>"
-                                                        class="small-text" style="margin-left:6px;" />
+                                                        class="small-text" style="margin-left:6px;"
+                                                        <?php disabled( $custom_hidden ); ?> />
                                                 </div>
+                                                </fieldset>
                                             </td>
                                         </tr>
                                         <tr>
@@ -1244,7 +1259,7 @@ class TIMU_WEBP_Support {
                                                 <td><?php echo esc_html( $saved_sz ); ?></td>
                                                 <td>
                                                     <?php if ( 'missing' === $status ) : ?>
-                                                        <span style="color:#d63638;"><?php esc_html_e( 'File Missing', 'thisismyurl-webp-support' ); ?></span>
+                                                        <span style="color:#d63638;"><span aria-hidden="true">&#9888; </span><strong><?php esc_html_e( 'File Missing', 'thisismyurl-webp-support' ); ?></strong></span>
                                                     <?php elseif ( 'disabled_by_settings' === $status ) : ?>
                                                         <span class="description"><?php esc_html_e( 'Excluded by Settings', 'thisismyurl-webp-support' ); ?></span>
                                                     <?php elseif ( $orig && 'external' !== $orig ) : ?>

--- a/thisismyurl-webp-support.php
+++ b/thisismyurl-webp-support.php
@@ -3,7 +3,7 @@
  * Plugin Name:       This Is My URL - WEBP Support
  * Plugin URI:        https://thisismyurl.com/thisismyurl-webp-support/
  * Description:       Non-destructive WebP/AVIF conversion with backups, bulk processing, and one-click restoration.
- * Version:           1.6147
+ * Version:           1.6148.2110
  * Author:            Christopher Ross
  * Author URI:        https://thisismyurl.com/
  * Requires at least: 6.0

--- a/thisismyurl-webp-support.php
+++ b/thisismyurl-webp-support.php
@@ -1393,6 +1393,8 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
     require_once plugin_dir_path( __FILE__ ) . 'includes/class-timu-webp-cli.php';
 }
 
+require_once plugin_dir_path( __FILE__ ) . 'includes/abilities.php';
+
 TIMU_WEBP_Support::init();
 
 require_once plugin_dir_path( __FILE__ ) . 'github-updater.php';

--- a/uninstall.php
+++ b/uninstall.php
@@ -24,5 +24,6 @@ if ( ! empty( $options['delete_backups_uninstall'] ) && $wp_filesystem && $wp_fi
 
 delete_metadata( 'post', 0, '_webp_original_path', '', true );
 delete_metadata( 'post', 0, '_webp_savings', '', true );
+delete_metadata( 'post', 0, '_webp_companion_path', '', true );
 delete_option( 'timu_webp_support_options' );
 wp_cache_flush();


### PR DESCRIPTION
WP 7 hardening pass — thisismyurl-webp-support.

Recommendation: **QUICK** (contained fixes — quick activation check then merge + tag).

Changes (4 commits):
- Add WP 7 Abilities API support
- Fix P0-5/P1/P2 a11y findings: progressbar role + live region, fieldsets, non-colour state, hidden-input AT guard
- Fix P2: delete _webp_companion_path meta on uninstall
- Stamp release version 1.6148.2110

Audit + scorecard: clients/thisismyurl/plugin-line-hardening/HARDENING-AUDIT.md
All files php -l clean. Version stamped X.6148.2110 (Toronto).